### PR TITLE
Adding Stanza option to TTR, Entity Grid

### DIFF
--- a/src/TRUNAJOD/entity_grid.py
+++ b/src/TRUNAJOD/entity_grid.py
@@ -18,6 +18,7 @@ It is also worth noting, that we consider an entity grid of two-sentence
 sequence and the API currently does not provide any hyper-parameter tunning to
 change this.
 """
+from TRUNAJOD.utils import SupportedModels
 
 UNIVERSAL_NOUN_TAGS = set([u'NOUN', u'PRON', u'PROPN'])
 
@@ -63,7 +64,7 @@ class EntityGrid(object):
     module. It only supports 2-transitions entity grid.
     """
 
-    def __init__(self, doc, model="spacy"):
+    def __init__(self, doc, model_name="spacy"):
         """Construct EntityGrid object."""
         # Initialization
         entity_map = dict()
@@ -88,11 +89,13 @@ class EntityGrid(object):
             u'-X': 0,
             u'--': 0
         }
+        # check model
+        model = SupportedModels(model_name)
 
         # Get number of sentences in the text
-        if model == "spacy":
+        if model == SupportedModels.SPACY:
             n_sent = len(list(doc.sents))
-        elif model == "stanza":
+        elif model == SupportedModels.STANZA:
             n_sent = len(list(doc.sentences))
 
         # To get coherence measurements we need at least 2 sentences
@@ -102,7 +105,7 @@ class EntityGrid(object):
                 .format(n_sent))
 
         # For each sentence, get dependencies and its grammatical role
-        if model == "spacy":
+        if model == SupportedModels.SPACY:
             for sent in doc.sents:
                 for token in sent:
                     if token.pos_ in UNIVERSAL_NOUN_TAGS:
@@ -112,7 +115,7 @@ class EntityGrid(object):
                             entity_grid[token.text.upper()] = [u'-'] * n_sent
                 i += 1
                 entity_map['s%d' % i] = []
-        elif model == "stanza":
+        elif model == SupportedModels.STANZA:
             for sent in doc.sentences:
                 for word in sent.words:
                     if word.upos in UNIVERSAL_NOUN_TAGS:

--- a/src/TRUNAJOD/ttr.py
+++ b/src/TRUNAJOD/ttr.py
@@ -8,7 +8,7 @@ the text this measurement is 1, and if there is infinite repetition, it will
 tend to 0. This measurement is not recommended if analyzing texts of different
 lengths, as when the number of tokens increases, the TTR tends flatten.
 """
-from TRUNAJOD.utils import is_word
+from TRUNAJOD.utils import SupportedModels,is_word
 
 # dev import
 # from src.TRUNAJOD.utils import is_word
@@ -25,7 +25,7 @@ def type_token_ratio(word_list):
     return len(set(word_list)) / len(word_list)
 
 
-def lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
+def lexical_diversity_mtld(doc, model_name="spacy", ttr_segment=0.72):
     """Compute MTLD lexical diversity in a bi-directional fashion.
 
     :param doc: Processed text
@@ -33,12 +33,15 @@ def lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
     :return: Bi-directional lexical diversity MTLD
     :rtype: float
     """
+    # check model
+    model = SupportedModels(model_name)
+
     word_list = []
-    if model == "spacy":
+    if model == SupportedModels.SPACY:
         for token in doc:
             if is_word(token.pos_):
                 word_list.append(token.lemma_)
-    elif model == "stanza":
+    elif model == SupportedModels.STANZA:
         for sent in doc.sentences:
             for word in sent.words:
                 if is_word(word.upos):
@@ -47,7 +50,7 @@ def lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
             one_side_lexical_diversity_mtld(word_list[::-1], model, ttr_segment)) / 2
 
 
-def one_side_lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
+def one_side_lexical_diversity_mtld(doc, model_name="spacy", ttr_segment=0.72):
     """Lexical diversity per MTLD.
 
     :param doc: Tokenized text
@@ -62,7 +65,10 @@ def one_side_lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
     non_ttr_segment = 1 - ttr_segment
     word_list = []
 
-    if model == "spacy" or type(doc) == list:
+    # check model
+    model = SupportedModels(model_name)
+
+    if model == SupportedModels.SPACY or type(doc) == list:
         for token in doc:
             word_list.append(token.lower())
             total_words += 1
@@ -70,7 +76,7 @@ def one_side_lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
             if ttr < ttr_segment:
                 word_list = []
                 factor += 1
-    elif model == "stanza":
+    elif model == SupportedModels.STANZA:
         if type(doc) != list:
             for sent in doc.sentences:
                 for word in sent.words:
@@ -85,5 +91,4 @@ def one_side_lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
         factor += 1 - (
             type_token_ratio(word_list) - ttr_segment) / non_ttr_segment
         total_words += 1
-
     return total_words / factor

--- a/src/TRUNAJOD/ttr.py
+++ b/src/TRUNAJOD/ttr.py
@@ -10,6 +10,9 @@ lengths, as when the number of tokens increases, the TTR tends flatten.
 """
 from TRUNAJOD.utils import is_word
 
+# dev import
+# from src.TRUNAJOD.utils import is_word
+
 
 def type_token_ratio(word_list):
     """Return Type Token Ratio of a word list.
@@ -22,27 +25,33 @@ def type_token_ratio(word_list):
     return len(set(word_list)) / len(word_list)
 
 
-def lexical_diversity_mtld(doc, ttr_segment=0.72):
+def lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
     """Compute MTLD lexical diversity in a bi-directional fashion.
 
     :param doc: Processed text
-    :type doc: Spacy Doc
+    :type doc: NLP Doc
     :return: Bi-directional lexical diversity MTLD
     :rtype: float
     """
     word_list = []
-    for token in doc:
-        if is_word(token.pos_):
-            word_list.append(token.lemma_)
-    return (one_side_lexical_diversity_mtld(word_list, ttr_segment) +
-            one_side_lexical_diversity_mtld(word_list[::-1], ttr_segment)) / 2
+    if model == "spacy":
+        for token in doc:
+            if is_word(token.pos_):
+                word_list.append(token.lemma_)
+    elif model == "stanza":
+        for sent in doc.sentences:
+            for word in sent.words:
+                if is_word(word.upos):
+                    word_list.append(word.lemma)
+    return (one_side_lexical_diversity_mtld(word_list, model, ttr_segment) +
+            one_side_lexical_diversity_mtld(word_list[::-1], model, ttr_segment)) / 2
 
 
-def one_side_lexical_diversity_mtld(doc, ttr_segment=0.72):
+def one_side_lexical_diversity_mtld(doc, model="spacy", ttr_segment=0.72):
     """Lexical diversity per MTLD.
 
     :param doc: Tokenized text
-    :type doc: Spacy Doc
+    :type doc: NLP Doc
     :param ttr_segment: Threshold for TTR mean computation
     :type ttr_segment: float
     :return: MLTD lexical diversity
@@ -52,13 +61,25 @@ def one_side_lexical_diversity_mtld(doc, ttr_segment=0.72):
     total_words = 0
     non_ttr_segment = 1 - ttr_segment
     word_list = []
-    for token in doc:
-        word_list.append(token.lower())
-        total_words += 1
-        ttr = type_token_ratio(word_list)
-        if ttr < ttr_segment:
-            word_list = []
-            factor += 1
+
+    if model == "spacy" or type(doc) == list:
+        for token in doc:
+            word_list.append(token.lower())
+            total_words += 1
+            ttr = type_token_ratio(word_list)
+            if ttr < ttr_segment:
+                word_list = []
+                factor += 1
+    elif model == "stanza":
+        if type(doc) != list:
+            for sent in doc.sentences:
+                for word in sent.words:
+                    word_list.append(word.text.lower())
+                    total_words += 1
+                    ttr = type_token_ratio(word_list)
+                    if ttr < ttr_segment:
+                        word_list = []
+                        factor += 1
 
     if word_list:
         factor += 1 - (

--- a/src/TRUNAJOD/utils.py
+++ b/src/TRUNAJOD/utils.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """Utility functions for TRUNAJOD library."""
+from enum import Enum
 
+
+class SupportedModels(str, Enum):
+    SPACY = "spacy"
+    STANZA = "stanza"
 
 def flatten(list_of_lists):
     """Flatten a list of list.

--- a/stanza_example.py
+++ b/stanza_example.py
@@ -1,5 +1,5 @@
-from src.TRUNAJOD.entity_grid import EntityGrid
-from src.TRUNAJOD.ttr import lexical_diversity_mtld, one_side_lexical_diversity_mtld
+from TRUNAJOD.entity_grid import EntityGrid
+from TRUNAJOD.ttr import lexical_diversity_mtld, one_side_lexical_diversity_mtld
 import spacy
 import stanza
 """
@@ -29,12 +29,12 @@ doc_s = nlp_s(example_text)
 # TTR Check - change TTR import to test
 print("spacy result: ", lexical_diversity_mtld(doc))
 # or
-# print("spacy result: ", lexical_diversity_mtld(doc, model="spacy"))
-print("stanza result: ", lexical_diversity_mtld(doc_s, model="stanza"))
+# print("spacy result: ", lexical_diversity_mtld(doc, model_name="spacy"))
+print("stanza result: ", lexical_diversity_mtld(doc_s, model_name="stanza"))
 
 # Entity Grid Check
 egrid = EntityGrid(doc)
-egrid_s = EntityGrid(doc_s, model="stanza")
+egrid_s = EntityGrid(doc_s, model_name="stanza")
 
 print("spacy Entity grid:")
 print(egrid.get_egrid())

--- a/stanza_test.py
+++ b/stanza_test.py
@@ -1,0 +1,43 @@
+from src.TRUNAJOD.entity_grid import EntityGrid
+from src.TRUNAJOD.ttr import lexical_diversity_mtld, one_side_lexical_diversity_mtld
+import spacy
+import stanza
+"""
+MUST CHANGE TTR IMPORT TO WORK
+"""
+# Load spaCy model
+nlp = spacy.load("es_core_news_sm")
+
+# Load stanza model
+nlp_s = stanza.Pipeline('es', use_gpu=False)
+
+# Example
+example_text = (
+    "El espectáculo del cielo nocturno cautiva la mirada y suscita preguntas"
+    "sobre el universo, su origen y su funcionamiento. No es sorprendente que "
+    "todas las civilizaciones y culturas hayan formado sus propias "
+    "cosmologías. Unas relatan, por ejemplo, que el universo ha"
+    "sido siempre tal como es, con ciclos que inmutablemente se repiten; "
+    "otras explican que este universo ha tenido un principio, "
+    "que ha aparecido por obra creadora de una divinidad."
+)
+
+# Create Doc
+doc = nlp(example_text)
+doc_s = nlp_s(example_text)
+
+# TTR Check - change TTR import to test
+print("spacy result: ", lexical_diversity_mtld(doc))
+# or
+# print("spacy result: ", lexical_diversity_mtld(doc, model="spacy"))
+print("stanza result: ", lexical_diversity_mtld(doc_s, model="stanza"))
+
+# Entity Grid Check
+egrid = EntityGrid(doc)
+egrid_s = EntityGrid(doc_s, model="stanza")
+
+print("spacy Entity grid:")
+print(egrid.get_egrid())
+
+print("stanza Entity grid:")
+print(egrid_s.get_egrid())

--- a/tester.py
+++ b/tester.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Type Token Ratios module.
+
+Type token ratios (TTR) are a measurement of lexical diversity. They are
+defined as the ratio of unique tokens divided by the total number of tokens.
+This measurement is bounded between 0 and 1. If there is no repetition in
+the text this measurement is 1, and if there is infinite repetition, it will
+tend to 0. This measurement is not recommended if analyzing texts of different
+lengths, as when the number of tokens increases, the TTR tends flatten.
+"""
+from TRUNAJOD.utils import is_word
+
+
+def type_token_ratio(word_list):
+    """Return Type Token Ratio of a word list.
+
+    :param word_list: List of words
+    :type word_list: List of strings
+    :return: TTR of the word list
+    :rtype: float
+    """
+    return len(set(word_list)) / len(word_list)
+
+
+def lexical_diversity_mtld(doc, ttr_segment=0.72):
+    """Compute MTLD lexical diversity in a bi-directional fashion.
+
+    :param doc: Processed text
+    :type doc: Spacy Doc
+    :return: Bi-directional lexical diversity MTLD
+    :rtype: float
+    """
+    word_list = []
+    for token in doc:
+        if is_word(token.pos_):
+            word_list.append(token.lemma_)
+    return (one_side_lexical_diversity_mtld(word_list, ttr_segment) +
+            one_side_lexical_diversity_mtld(word_list[::-1], ttr_segment)) / 2
+
+
+def one_side_lexical_diversity_mtld(doc, ttr_segment=0.72):
+    """Lexical diversity per MTLD.
+
+    :param doc: Tokenized text
+    :type doc: Spacy Doc
+    :param ttr_segment: Threshold for TTR mean computation
+    :type ttr_segment: float
+    :return: MLTD lexical diversity
+    :rtype: float
+    """
+    factor = 0
+    total_words = 0
+    non_ttr_segment = 1 - ttr_segment
+    word_list = []
+    for token in doc:
+        word_list.append(token.lower())
+        total_words += 1
+        ttr = type_token_ratio(word_list)
+        if ttr < ttr_segment:
+            word_list = []
+            factor += 1
+
+    if word_list:
+        factor += 1 - (
+            type_token_ratio(word_list) - ttr_segment) / non_ttr_segment
+        total_words += 1
+
+    return total_words / factor

--- a/tests/ttr_test.py
+++ b/tests/ttr_test.py
@@ -7,13 +7,13 @@ from TRUNAJOD import ttr
 def test_type_token_ratio():
     """Test type_token_ratio func."""
     assert ttr.type_token_ratio(
-        ['hola', 'hola', 'chao', 'hola', 'perro', 'hola'], ) == 0.5
+        ['hola', 'hola', 'chao', 'hola', 'perro', 'hola']) == 0.5
 
 
 def test_one_side_lexical_diversity_mtld():
     """Test one_side_lexical_diversity_mtld."""
     assert ttr.one_side_lexical_diversity_mtld(
-        ['hola', 'hola', 'chao', 'hola', 'perro', 'hola'], 1) == 3
+        ['hola', 'hola', 'chao', 'hola', 'perro', 'hola'], ttr_segment=1) == 3
 
 
 def test_lexical_diversity_mtld():
@@ -27,4 +27,4 @@ def test_lexical_diversity_mtld():
         Token('perro', 'perro'),
         Token('hola', 'hola'),
     ]
-    assert ttr.lexical_diversity_mtld(doc, 1) == 3
+    assert ttr.lexical_diversity_mtld(doc, ttr_segment=1) == 3


### PR DESCRIPTION
Hello. First of all, thanks for making the amazing repo available.

I made the necessary changes to TTR and Entity Grid files, adding the Stanza option.
The major issue to tackle was the two models' different architectures and how one could access the token class.
I handled the differences in such architectures. 

Quite notably, there's now an option in TTR and Entity Grid methods to choose Stanza by passing in (model="Stanza").
The model default is set to spaCy.

The examples are available in stanza_test.py.
spaCy and Stanza results differ by a slight margin.

